### PR TITLE
Optimized compilation and added compilation testing workflow

### DIFF
--- a/.github/workflows/check-compilation.yml
+++ b/.github/workflows/check-compilation.yml
@@ -1,0 +1,53 @@
+name: Check Compilation for Chips (Default Features)
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  compile:
+    name: ${{ matrix.chip.feature }} (${{ matrix.chip.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        chip:
+          - feature: esp32
+            target: xtensa-esp32-none-elf
+            toolchain: esp
+          - feature: esp32c2
+            target: riscv32imc-unknown-none-elf
+            toolchain: stable
+          - feature: esp32c3
+            target: riscv32imc-unknown-none-elf
+            toolchain: stable
+          - feature: esp32c6
+            target: riscv32imac-unknown-none-elf
+            toolchain: stable
+          - feature: esp32s3
+            target: xtensa-esp32s3-none-elf
+            toolchain: esp
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install ESP Rust toolchain
+        uses: esp-rs/xtensa-toolchain@v1.6.0
+        with:
+          default: false
+          buildtargets: ${{ matrix.chip.feature }}
+          version: 1.93.0.0
+        env:
+          RUSTUP_PERMIT_COPY_RENAME: 1
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN || github.token }}
+
+      - name: Check ${{ matrix.chip.feature }} with default features
+        run: cargo +${{ matrix.chip.toolchain }} check --locked --release --target ${{ matrix.chip.target }} --features ${{ matrix.chip.feature }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,8 +738,9 @@ dependencies = [
 
 [[package]]
 name = "esp-csi-rs"
-version = "0.4.1"
-source = "git+https://github.com/csi-rs/esp-csi-rs?rev=74707d4fcd2624b323e69115b61bea47f4532582#74707d4fcd2624b323e69115b61bea47f4532582"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "314df2a34271268c7c70720b212b1fffe8a2ec8c281c8307a24501e84ff1f61e"
 dependencies = [
  "defmt 1.0.1",
  "defmt-rtt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,8 +739,7 @@ dependencies = [
 [[package]]
 name = "esp-csi-rs"
 version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "414f580b0768967cd26cf1d7b0cf85c85dc3fd4f6314319044022c96d6e6e1e9"
+source = "git+https://github.com/csi-rs/esp-csi-rs?rev=74707d4fcd2624b323e69115b61bea47f4532582#74707d4fcd2624b323e69115b61bea47f4532582"
 dependencies = [
  "defmt 1.0.1",
  "defmt-rtt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ embassy-time = { version = "0.5.0" }
 static_cell = { version = "2.1.1" }
 embassy-sync = { version = "0.7.0" }
 embassy-futures = { version = "0.1.1" }
-esp-csi-rs = { version = "0.4.1", default-features = false }
+esp-csi-rs = { git = "https://github.com/csi-rs/esp-csi-rs", rev = "74707d4fcd2624b323e69115b61bea47f4532582", default-features = false }
 menu = "0.6.1"
 embedded-io = "0.6.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ embassy-time = { version = "0.5.0" }
 static_cell = { version = "2.1.1" }
 embassy-sync = { version = "0.7.0" }
 embassy-futures = { version = "0.1.1" }
-esp-csi-rs = { git = "https://github.com/csi-rs/esp-csi-rs", rev = "74707d4fcd2624b323e69115b61bea47f4532582", default-features = false }
+esp-csi-rs = { version = "0.4.2", default-features = false }
 menu = "0.6.1"
 embedded-io = "0.6.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,12 +89,15 @@ embedded-io = "0.6.1"
 incremental = true
 debug = 2
 opt-level = "s"
+[profile.dev.package."*"]
+opt-level = 3
 
 [profile.release]
 codegen-units = 1        # LLVM can perform better optimizations using a single thread
 debug-assertions = false
 incremental = false
 lto = 'fat'
-opt-level = "s"
+opt-level = 3
 overflow-checks = false
-panic = "abort"
+[profile.release.package."*"]
+opt-level = 3

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,7 +7,7 @@ use menu::{Item, ItemType, Menu, Parameter};
 
 use crate::cli::cmds::{reset_config, set_collection_mode, set_csi, set_log_mode, set_traffic, set_wifi, show_config, start_csi_collect};
 pub use crate::cli::serial::SerialInterface;
-#[cfg(not(feature = "esp32"))]
+#[cfg(any(feature = "esp32c3", feature = "esp32c6", feature = "esp32s3"))]
 pub use crate::cli::serial::is_jtag;
 
 /// Placeholder context passed through the `menu` crate to every command callback.

--- a/src/cli/serial.rs
+++ b/src/cli/serial.rs
@@ -1,5 +1,5 @@
 use esp_hal::uart::Uart;
-#[cfg(not(feature = "esp32"))]
+#[cfg(any(feature = "esp32c3", feature = "esp32c6", feature = "esp32s3"))]
 use esp_hal::usb_serial_jtag::UsbSerialJtag;
 use esp_hal::Async;
 
@@ -10,11 +10,23 @@ use esp_hal::Async;
 pub type SerialInterface<'d> = Uart<'d, Async>;
 
 /// Serial interface type used when `jtag-serial` is explicitly requested (non-ESP32).
-#[cfg(all(not(feature = "esp32"), not(feature = "auto"), feature = "jtag-serial"))]
+#[cfg(all(
+    any(feature = "esp32c3", feature = "esp32c6", feature = "esp32s3"),
+    not(feature = "auto"),
+    feature = "jtag-serial"
+))]
 pub type SerialInterface<'d> = UsbSerialJtag<'d, Async>;
+
+/// ESP32-C2 has no USB Serial/JTAG peripheral, so force UART even if `jtag-serial` is selected.
+#[cfg(all(feature = "esp32c2", not(feature = "auto"), feature = "jtag-serial"))]
+pub type SerialInterface<'d> = Uart<'d, Async>;
 
 /// Serial interface type used when UART is explicitly requested (non-ESP32, no auto-detect).
 #[cfg(all(not(feature = "esp32"), not(feature = "auto"), feature = "uart"))]
+pub type SerialInterface<'d> = Uart<'d, Async>;
+
+/// In `auto` mode, ESP32-C2 always uses UART because USB Serial/JTAG is unavailable.
+#[cfg(all(feature = "esp32c2", feature = "auto"))]
 pub type SerialInterface<'d> = Uart<'d, Async>;
 
 /// Runtime-selectable serial interface for targets that support both UART and USB-JTAG.
@@ -22,7 +34,10 @@ pub type SerialInterface<'d> = Uart<'d, Async>;
 /// When the `auto` feature is enabled the correct backend is chosen at runtime by
 /// [`is_jtag`]: if a USB host is detected the JTAG peripheral is used, otherwise
 /// UART0 is used as a fallback.
-#[cfg(all(not(feature = "esp32"), feature = "auto"))]
+#[cfg(all(
+    any(feature = "esp32c3", feature = "esp32c6", feature = "esp32s3"),
+    feature = "auto"
+))]
 pub enum SerialInterface<'d> {
     /// USB Serial JTAG backend (faster, preferred when a USB host is present).
     UsbJtag(UsbSerialJtag<'d, Async>),
@@ -30,7 +45,10 @@ pub enum SerialInterface<'d> {
     Uart(Uart<'d, Async>),
 }
 
-#[cfg(all(not(feature = "esp32"), feature = "auto"))]
+#[cfg(all(
+    any(feature = "esp32c3", feature = "esp32c6", feature = "esp32s3"),
+    feature = "auto"
+))]
 impl<'d> core::fmt::Write for SerialInterface<'d> {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
         match self {
@@ -40,12 +58,18 @@ impl<'d> core::fmt::Write for SerialInterface<'d> {
     }
 }
 
-#[cfg(all(not(feature = "esp32"), feature = "auto"))]
+#[cfg(all(
+    any(feature = "esp32c3", feature = "esp32c6", feature = "esp32s3"),
+    feature = "auto"
+))]
 impl<'d> embedded_io::ErrorType for SerialInterface<'d> {
     type Error = embedded_io::ErrorKind;
 }
 
-#[cfg(all(not(feature = "esp32"), feature = "auto"))]
+#[cfg(all(
+    any(feature = "esp32c3", feature = "esp32c6", feature = "esp32s3"),
+    feature = "auto"
+))]
 impl<'d> embedded_io_async::Read for SerialInterface<'d> {
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         use embedded_io::Error;
@@ -57,7 +81,10 @@ impl<'d> embedded_io_async::Read for SerialInterface<'d> {
     }
 }
 
-#[cfg(all(not(feature = "esp32"), feature = "auto"))]
+#[cfg(all(
+    any(feature = "esp32c3", feature = "esp32c6", feature = "esp32s3"),
+    feature = "auto"
+))]
 impl<'d> embedded_io::Write for SerialInterface<'d> {
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
         use embedded_io::Error;
@@ -90,7 +117,10 @@ impl<'d> embedded_io::Write for SerialInterface<'d> {
 /// chip-specific and are selected via Cargo features at compile time.
 ///
 /// Not available on ESP32 which has no USB-Serial-JTAG peripheral.
-#[cfg(all(not(feature = "esp32"), feature = "auto"))]
+#[cfg(all(
+    any(feature = "esp32c3", feature = "esp32c6", feature = "esp32s3"),
+    feature = "auto"
+))]
 pub fn is_jtag() -> bool {
     #[cfg(feature = "esp32c3")]
     const USB_DEVICE_INT_RAW: *const u32 = 0x60043008 as *const u32;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,9 +5,14 @@ mod cli;
 mod config;
 
 use crate::config::{UserConfig, DONE_SIGNAL, IS_COLLECTING, START_SIGNAL, USER_CONFIG};
-#[cfg(not(feature = "esp32"))]
+#[cfg(any(feature = "esp32c3", feature = "esp32c6", feature = "esp32s3"))]
 use cli::is_jtag;
-use cli::{Context, SerialInterface, ROOT_MENU};
+use cli::{Context, ROOT_MENU};
+#[cfg(all(
+    feature = "auto",
+    any(feature = "esp32c3", feature = "esp32c6", feature = "esp32s3")
+))]
+use cli::SerialInterface;
 use core::sync::atomic::Ordering;
 use embassy_executor::Spawner;
 use embassy_futures::join::join;
@@ -23,7 +28,10 @@ use esp_csi_rs::{
 use esp_hal::timer::timg::TimerGroup;
 #[cfg(any(feature = "auto", feature = "uart"))]
 use esp_hal::uart::Uart;
-#[cfg(all(any(feature = "auto", feature = "jtag-serial"), not(feature = "esp32")))]
+#[cfg(all(
+    any(feature = "auto", feature = "jtag-serial"),
+    any(feature = "esp32c3", feature = "esp32c6", feature = "esp32s3")
+))]
 use esp_hal::usb_serial_jtag::UsbSerialJtag;
 use esp_radio::wifi::{AuthMethod, ClientConfig, Interfaces, WifiController};
 use menu::*;
@@ -73,13 +81,13 @@ async fn main(spawner: Spawner) {
     esp_alloc::heap_allocator!(size: 61 * 1024);
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
-    #[cfg(any(feature = "esp32c6", feature = "esp32c3"))]
+    #[cfg(any(feature = "esp32c2", feature = "esp32c3", feature = "esp32c6"))]
     {
         let sw_interrupt =
             esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
         esp_rtos::start(timg0.timer0, sw_interrupt.software_interrupt0);
     }
-    #[cfg(not(any(feature = "esp32c6", feature = "esp32c3")))]
+    #[cfg(not(any(feature = "esp32c2", feature = "esp32c3", feature = "esp32c6")))]
     esp_rtos::start(timg0.timer0);
 
     // Initialize ESP radio Controller
@@ -127,9 +135,20 @@ async fn main(spawner: Spawner) {
         }
 
         // Forced JTAG
-        #[cfg(feature = "jtag-serial")]
+        #[cfg(all(
+            feature = "jtag-serial",
+            any(feature = "esp32c3", feature = "esp32c6", feature = "esp32s3")
+        ))]
         {
             UsbSerialJtag::new(peripherals.USB_DEVICE).into_async()
+        }
+
+        // ESP32-C2: no USB Serial/JTAG peripheral, always use UART.
+        #[cfg(all(feature = "esp32c2", feature = "jtag-serial"))]
+        {
+            Uart::new(peripherals.UART0, esp_hal::uart::Config::default())
+                .unwrap()
+                .into_async()
         }
 
         // Forced UART
@@ -141,28 +160,30 @@ async fn main(spawner: Spawner) {
         }
 
         // Runtime Auto-Detection
-        #[cfg(all(not(feature = "esp32"), feature = "auto"))]
+        #[cfg(all(
+            any(feature = "esp32c3", feature = "esp32c6", feature = "esp32s3"),
+            feature = "auto"
+        ))]
         {
-            #[cfg(feature = "esp32")]
-            {
-                Uart::new(peripherals.UART0, esp_hal::uart::Config::default())
-                    .unwrap()
-                    .into_async()
+            if is_jtag() {
+                SerialInterface::UsbJtag(
+                    UsbSerialJtag::new(peripherals.USB_DEVICE).into_async(),
+                )
+            } else {
+                SerialInterface::Uart(
+                    Uart::new(peripherals.UART0, esp_hal::uart::Config::default())
+                        .unwrap()
+                        .into_async(),
+                )
             }
-            #[cfg(not(feature = "esp32"))]
-            {
-                if is_jtag() {
-                    SerialInterface::UsbJtag(
-                        UsbSerialJtag::new(peripherals.USB_DEVICE).into_async(),
-                    )
-                } else {
-                    SerialInterface::Uart(
-                        Uart::new(peripherals.UART0, esp_hal::uart::Config::default())
-                            .unwrap()
-                            .into_async(),
-                    )
-                }
-            }
+        }
+
+        // ESP32-C2: auto mode falls back to UART because USB Serial/JTAG is unavailable.
+        #[cfg(all(feature = "esp32c2", feature = "auto"))]
+        {
+            Uart::new(peripherals.UART0, esp_hal::uart::Config::default())
+                .unwrap()
+                .into_async()
         }
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ use esp_csi_rs::{
 use esp_hal::timer::timg::TimerGroup;
 #[cfg(any(feature = "auto", feature = "uart"))]
 use esp_hal::uart::Uart;
-#[cfg(any(feature = "auto", feature = "jtag-serial"))]
+#[cfg(all(any(feature = "auto", feature = "jtag-serial"), not(feature = "esp32")))]
 use esp_hal::usb_serial_jtag::UsbSerialJtag;
 use esp_radio::wifi::{AuthMethod, ClientConfig, Interfaces, WifiController};
 use menu::*;


### PR DESCRIPTION
## Summary
This PR improves build reliability across ESP targets and introduces CI workflow coverage to continuously validate chip-specific compilation with default features.

### What changed
1. Added a compilation testing workflow for chip matrix validation.
2. Fixed esp32c2 compilation compatibility by making serial handling chip-aware:
USB Serial/JTAG paths only compile on chips that support them (esp32c3, esp32c6, esp32s3)
esp32c2 uses UART-only paths in auto / jtag-serial scenarios